### PR TITLE
버튼 컴포넌트 분리

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -4,7 +4,7 @@ const Button = ({
   onClick,
   ariaLabel,
 }: {
-  value: string;
+  value: any;
   className?: string;
   onClick?: () => void;
   ariaLabel?: string;

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -1,11 +1,13 @@
 import useMovieDetail from "../hooks/useMovieDetail";
 import { Genre, Member, Review, Video } from "../types/Movie";
 import "../styles/Detail.css";
+import Button from "../components/Button";
 
 const DetailPage = () => {
   const { movieData, reviews, isLoading, error, getReleaseYear, changeTimeFormat, getImageUrl } = useMovieDetail();
 
-  // 데이터가 없는 경우
+  if (isLoading) return <div>로딩중...</div>;
+  if (error) return <div>에러: {error.message}</div>;
   if (!movieData) {
     return (
       <div className="detail-page">
@@ -48,22 +50,109 @@ const DetailPage = () => {
             </div>
             <div className="get-my-list">
               <div className="purchase-section">
-                <button className="purchase-button">구매하기</button>
-                <button className="gift-button">선물하기</button>
+                <Button className="purchase-button" value="구매하기" />
+                <Button className="gift-button" value="선물하기" />
               </div>
               <div className="evaluation-section">
-                <button className="evaluation-section-button">
-                  <p>보고싶어요</p>
-                </button>
-                <button className="evaluation-section-button">
-                  <p>평가하기</p>
-                </button>
-                <button className="evaluation-section-button">
-                  <p>왓챠파티</p>
-                </button>
-                <button className="evaluation-section-button">
-                  <p>더보기</p>
-                </button>
+                <Button
+                  className="evaluation-section-button"
+                  value={
+                    <>
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="24"
+                        height="24"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <path
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          d="M12 2a.75.75 0 0 0-.75.75v8.5h-8.5a.75.75 0 0 0 0 1.5h8.5v8.5a.75.75 0 0 0 1.5 0v-8.5h8.5a.75.75 0 0 0 0-1.5h-8.5v-8.5A.75.75 0 0 0 12 2"
+                          clip-rule="evenodd"
+                        ></path>
+                      </svg>
+                      <p>보고싶어요</p>
+                    </>
+                  }
+                />
+                <Button
+                  className="evaluation-section-button"
+                  value={
+                    <>
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="24"
+                        height="24"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <path
+                          stroke="currentColor"
+                          stroke-width="1.5"
+                          d="m2.41 9.9-.52.53.52-.54 6.09-.88a1 1 0 0 0 .75-.55l2.73-5.52 2.72 5.52a1 1 0 0 0 .75.55l6.08.88-4.45 4.3a1 1 0 0 0-.3.89l.73-.13-.72.13 1.08 6.05-5.43-2.86a1 1 0 0 0-.93 0l-5.44 2.87 1.04-6.07a1 1 0 0 0-.3-.88z"
+                        ></path>
+                      </svg>
+                      <p>평가하기</p>
+                    </>
+                  }
+                />
+                <Button
+                  className="evaluation-section-button"
+                  value={
+                    <>
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="24"
+                        height="24"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <path
+                          fill="currentColor"
+                          d="M11 10a1 1 0 1 0 0-2 1 1 0 0 0 0 2M9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0M14 10a1 1 0 1 0 0-2 1 1 0 0 0 0 2"
+                        ></path>
+                        <path
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          d="M2 5c0-1.1.9-2 2-2h14a2 2 0 0 1 2 2v8.32a2 2 0 0 1-2 2h-8L6.72 18.7A1 1 0 0 1 5 18v-2.67H4a2 2 0 0 1-2-2zm3 8.72c.88 0 1.6.72 1.6 1.6v1.2l2.25-2.31c.3-.31.72-.49 1.15-.49h8a.4.4 0 0 0 .4-.4V5a.4.4 0 0 0-.4-.4H4a.4.4 0 0 0-.4.4v8.32c0 .22.18.4.4.4z"
+                          clip-rule="evenodd"
+                        ></path>
+                        <path
+                          fill="currentColor"
+                          d="M10 17.52c0 .45.36.8.8.8H15l3.28 3.38A1 1 0 0 0 20 21v-2.68h1a2 2 0 0 0 2-2V10.8a.8.8 0 0 0-1.6 0v5.52a.4.4 0 0 1-.4.4h-1c-.88 0-1.6.72-1.6 1.6v1.2l-2.25-2.31a1.6 1.6 0 0 0-1.15-.49h-4.2a.8.8 0 0 0-.8.8"
+                        ></path>
+                      </svg>
+                      <p>왓챠파티</p>
+                    </>
+                  }
+                />
+                <Button
+                  className="evaluation-section-button"
+                  value={
+                    <>
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="24"
+                        height="24"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <path
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                          d="M13.5 5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0M12 10.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3m0 7a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3"
+                          clip-rule="evenodd"
+                        ></path>
+                      </svg>
+                      <p>더보기</p>
+                    </>
+                  }
+                />
               </div>
             </div>
           </section>
@@ -72,7 +161,7 @@ const DetailPage = () => {
               <>
                 <img src={getImageUrl(movieData.backdrop)} alt="Detail Image" />
                 <div className="preview-overlay">
-                  <button className="preview-button">미리보기 &gt;</button>
+                  <Button className="preview-button" value={"미리보기 >"} />
                 </div>
               </>
             )}


### PR DESCRIPTION
## 개요 (Summary)
Detail 페이지에서 사용하는 버튼을 재사용 가능한 **Button 컴포넌트**로 교체했습니다.  
이를 통해 코드 중복을 줄이고, 일관된 스타일의 버튼을 유지할 수 있도록 개선했습니다.

---

## 변경 사항 (Changes)
- `DetailPage` 내 버튼을 공용 Button 컴포넌트로 대체
- 버튼 관련 스타일 및 속성 재사용 가능하도록 정리

---

## 관련 이슈 (Related Issues)
- Related to #15

