### PR TITLE
Feat: 장르 검색 결과 컨텐츠에서 장르 이동

### DIFF
--- a/src/components/ThemeTab.tsx
+++ b/src/components/ThemeTab.tsx
@@ -1,17 +1,36 @@
+import useSearchMovie from "../hooks/useSearchMovie";
 import Button from "./Button";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 interface ThemeTabProps {
   list: Array<{
     name: string;
+    id?: number;
   }>;
 }
 
 const ThemeTab = ({ list }: ThemeTabProps) => {
   const [activeName, setActiveName] = useState<string>(list[0]?.name ?? "");
+  const { genreId, searchByGenre } = useSearchMovie();
+
+  // genreId에 해당하는 아이템 찾기
+  const selectedItem = list.find((item) => item.id?.toString() === genreId);
+
+  useEffect(() => {
+    if (genreId && selectedItem) {
+      setActiveName(selectedItem.name);
+    }
+  }, [genreId, selectedItem]);
 
   const handleTabClick = (tabName: string) => {
     setActiveName(tabName);
+
+    // 클릭한 탭에 해당하는 아이템 찾기
+    const clickedItem = list.find((item) => item.name === tabName);
+
+    if (clickedItem && clickedItem.id) {
+      searchByGenre(clickedItem.id.toString());
+    }
   };
 
   return (

--- a/src/hooks/useSearchMovie.tsx
+++ b/src/hooks/useSearchMovie.tsx
@@ -6,9 +6,8 @@ import { fetchSearchKeywords, fetchSearchGenres } from "../utils/api";
 
 const useSearchMovie = () => {
   const location = useLocation();
-  const { query, setQuery, reset, searchList, setSearchList } = useSearchKeywordStore();
+  const { query, setQuery, genreId, setGenreId, reset, searchList, setSearchList } = useSearchKeywordStore();
   const [searchQuery, setSearchQuery] = useState("");
-  const [genreId, setGenreId] = useState<string>("");
 
   const searchMovieQuery = useQuery({
     queryKey: ["searchMovie", searchQuery],

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -9,7 +9,7 @@ import useSearchMovie from "../hooks/useSearchMovie";
 
 const SearchPage = () => {
   const { trendingList, genresList, highlightedIndex, handleMouseEnter, isLoading, isError } = useSearchMovies();
-  const { searchList, searchQuery, isLoading: isSearchLoading } = useSearchMovie();
+  const { searchList, searchQuery, isLoading: isSearchLoading, genreId } = useSearchMovie();
 
   const tabButtons = [
     {
@@ -41,7 +41,7 @@ const SearchPage = () => {
   if (searchList.length > 0) {
     return (
       <div>
-        <ThemeTab list={genresList} />
+        {genreId && <ThemeTab list={genresList} />}
         <section className="search-result">
           <ul>
             {searchList.map((movie) => (

--- a/src/stores/useSearchKeywordStore.ts
+++ b/src/stores/useSearchKeywordStore.ts
@@ -5,6 +5,8 @@ import { config } from "../../config/env";
 type SearchState = {
   query: string;
   setQuery: (value: string) => void;
+  genreId: string;
+  setGenreId: (value: string) => void;
   searchList: TransformedMovie[];
   setSearchList: (searchList: RawMovie[]) => void;
   reset: () => void;
@@ -13,6 +15,8 @@ type SearchState = {
 const useSearchKeywordStore = create<SearchState>((set) => ({
   query: "",
   setQuery: (value: string) => set({ query: value }),
+  genreId: "",
+  setGenreId: (value: string) => set({ genreId: value }),
   searchList: [],
   setSearchList: (searchList) =>
     set(() => ({


### PR DESCRIPTION
## 개요 (Summary)
검색 결과에 표시된 장르 버튼 클릭 시 해당 장르 영화 목록을 호출하도록 기능을 추가했습니다.  
이를 위해 `genreId`를 Zustand store에서 관리하여 여러 페이지에서 상태를 공유할 수 있도록 개선했습니다.

---

## 변경 사항 (Changes)
- 장르 검색 결과 내 버튼 클릭 시 해당 장르 페이지로 이동 처리
- `genreId`를 Zustand store에서 전역 상태로 관리
- 여러 페이지에서 동일한 장르 상태를 참조 및 공유 가능하도록 구조 개선
---

## 관련 이슈 (Related Issues)
- Related to #18

