### PR TITLE
Refactor: 캐러셀 구조 변경

### DIFF
--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -3,14 +3,10 @@ import { CarouselProps, Carousel as CarouselSlide } from "../types/Carousel";
 import Button from "./Button";
 import useCarousel from "../hooks/useCarousel";
 import "../styles/Carousel.css";
-import useMovieList from "../hooks/useMovieList";
 import { Genre } from "../types/Movie";
 
-const Carousel: React.FC<CarouselProps> = ({ height, articleWidth, layout = "overlay", category, slides }) => {
-  const { isLoading, error } = useMovieList();
-
+const Carousel: React.FC<CarouselProps> = ({ height, articleWidth, layout = "overlay", slides }) => {
   const {
-    movieList,
     containerRef,
     trackRef,
     transitionEnabled,
@@ -19,13 +15,11 @@ const Carousel: React.FC<CarouselProps> = ({ height, articleWidth, layout = "ove
     handleTransitionEnd,
     handlePrev,
     handleNext,
-  } = useCarousel({ category, articleWidth, slides });
+  } = useCarousel({ articleWidth, slides: slides ?? [] });
 
-  if (isLoading) return <div>로딩중...</div>;
-  if (error) return <div>에러: {error.message}</div>;
-  if (movieList.length === 0) return <div>데이터가 없습니다.</div>;
+  if (!slides || slides.length === 0) return <div>데이터가 없습니다.</div>;
 
-  const isGenres = Boolean(slides && slides.length > 0);
+  const isGenres = slides.length > 0 && !("image" in slides[0]);
 
   return (
     <div

--- a/src/hooks/useCarousel.tsx
+++ b/src/hooks/useCarousel.tsx
@@ -5,19 +5,7 @@ import { Carousel as CarouselSlide } from "../types/Carousel";
 
 type Slide = CarouselSlide | Genre;
 
-const useCarousel = ({
-  category,
-  articleWidth,
-  slides,
-}: {
-  category?: "popular" | "top20" | "now";
-  articleWidth: number;
-  slides?: Slide[];
-}) => {
-  const { getMoviesByCategory } = useMovieListStore();
-  const storeList = category ? (getMoviesByCategory(category) as CarouselSlide[]) : [];
-  const movieList: Slide[] = slides && slides.length > 0 ? slides : storeList;
-
+const useCarousel = ({ articleWidth, slides }: { articleWidth: number; slides: Slide[] }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [transitionEnabled, setTransitionEnabled] = useState(true);
   const [visibleCount, setVisibleCount] = useState(1);
@@ -54,7 +42,7 @@ const useCarousel = ({
     return () => window.removeEventListener("resize", handleResize);
   }, [calculateVisibleCount]);
 
-  const clonedSlides = [...movieList.slice(-visibleCount), ...movieList, ...movieList.slice(0, visibleCount)];
+  const clonedSlides = [...slides.slice(-visibleCount), ...slides, ...slides.slice(0, visibleCount)];
   const displayIndex = currentIndex + visibleCount;
 
   const handleNext = () => {
@@ -68,12 +56,12 @@ const useCarousel = ({
   };
 
   const handleTransitionEnd = () => {
-    if (currentIndex >= movieList.length) {
+    if (currentIndex >= slides.length) {
       setTransitionEnabled(false);
       setCurrentIndex(0);
     } else if (currentIndex < 0) {
       setTransitionEnabled(false);
-      setCurrentIndex(movieList.length - 1);
+      setCurrentIndex(slides.length - 1);
     }
   };
 
@@ -87,7 +75,6 @@ const useCarousel = ({
   }, [transitionEnabled, isInitialized]);
 
   return {
-    movieList,
     containerRef,
     trackRef,
     transitionEnabled,

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -3,8 +3,13 @@ import Button from "../components/Button";
 
 import "../styles/Page.css";
 import ThemeTab from "../components/ThemeTab";
+import useMovieList from "../hooks/useMovieList";
+import useMovieListStore from "../stores/useMovieListStore";
 
 const ListPage = () => {
+  const { isLoading, error } = useMovieList();
+  const { getMoviesByCategory } = useMovieListStore();
+
   const tabButtons = [
     {
       name: "추천",
@@ -22,24 +27,28 @@ const ListPage = () => {
       name: "성인+",
     },
   ];
+
+  if (isLoading) return <div>로딩중...</div>;
+  if (error) return <div>에러: {error.message}</div>;
+
   return (
     <div>
       <ThemeTab list={tabButtons} />
       {/* 메인 슬라이드 */}
       <section style={{ marginBottom: "40px" }}>
-        <Carousel height={642} articleWidth={1140} layout="overlay" category="popular" />
+        <Carousel height={642} articleWidth={1140} layout="overlay" slides={getMoviesByCategory("popular")} />
       </section>
       {/* 추천1 */}
       <section style={{ marginBottom: "40px" }}>
-        <Carousel height={289} articleWidth={421} layout="top" category="popular" />
+        <Carousel height={289} articleWidth={421} layout="top" slides={getMoviesByCategory("popular")} />
       </section>
       <section style={{ marginBottom: "40px" }}>
         <h2>개별 구매 Top 20</h2>
-        <Carousel height={200} articleWidth={400} layout="left" category="top20" />
+        <Carousel height={200} articleWidth={400} layout="left" slides={getMoviesByCategory("top20")} />
       </section>
       <section style={{ marginBottom: "40px" }}>
         <h2>새로 올라온 콘텐츠</h2>
-        <Carousel height={164} articleWidth={290} layout="none" category="now" />
+        <Carousel height={164} articleWidth={290} layout="none" slides={getMoviesByCategory("now")} />
       </section>
     </div>
   );


### PR DESCRIPTION
## 개요 (Summary)
기존에는  `Carousel` 내부에서 직접 API를 호출했으나,  
이제는 각 페이지에서 데이터를 호출하고 해당 데이터를 `Carousel`로 전달받도록 구조를 개선했습니다.  
이를 통해 컴포넌트의 역할을 단순화하고 API 호출 책임을 페이지 단위로 일원화했습니다.

---

## 변경 사항 (Changes)
- `useCarousel`에서 수행하던 API 호출 로직을 `ListPage`로 이동
- `Carousel` 컴포넌트가 직접 API를 호출하던 방식을 제거
- `ListPage`에서 불러온 데이터를 `Carousel`로 props를 통해 전달하도록 수정

---

## 관련 이슈 (Related Issues)
- Related to #24

