### PR TITLE
refactor: index.html 캐시 되지 않도록 설정

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,9 @@
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
     <title>WATCHA Clone Coding</title>
   </head>
   <body>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -50,6 +50,11 @@ module.exports = {
       template: "./public/index.html", // 템플릿 파일 경로
       filename: "index.html", // 생성될 HTML 파일 이름
       inject: "body", // 스크립트를 body 태그 끝에 삽입
+      meta: {
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Pragma': 'no-cache',
+        'Expires': '0',
+      }// index.html은 캐시 안되게
     }),
     new ForkTsCheckerWebpackPlugin({
       async: false,


### PR DESCRIPTION
## 개요 (Summary)
`index.html` 파일이 브라우저에 캐시되지 않도록 메타데이터를 추가했습니다.  
이를 통해 배포 후 최신 버전이 즉시 반영되도록 개선했습니다.

---

## 변경 사항 (Changes)
1. `index.html`에 캐시 방지용 메타 태그 추가
2. Webpack `HtmlWebpackPlugin` 설정에 캐시 방지 메타 태그 추가

---

## 관련 이슈 (Related Issues)
- Related to #35

