### PR TITLE
refactor: 스켈레톤 UI 적용

### DIFF
--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,339 @@
+import React, { memo } from "react";
+import "@/styles/Skeleton.css";
+
+interface SkeletonProps {
+  width?: string | number;
+  height?: string | number;
+  borderRadius?: string | number;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const Skeleton: React.FC<SkeletonProps> = memo(({
+  width = "100%",
+  height = "20px",
+  borderRadius = "4px",
+  className = "",
+  style = {},
+}) => {
+  return (
+    <div
+      className={`skeleton ${className}`}
+      style={{
+        width,
+        height,
+        borderRadius,
+        ...style,
+      }}
+      aria-hidden="true"
+      role="presentation"
+    />
+  );
+});
+
+// 영화 카드용 스켈레톤
+const MovieCardSkeleton: React.FC<{ layout?: "overlay" | "top" | "left" | "none" }> = memo(({ 
+  layout = "top" 
+}) => {
+  if (layout === "overlay") {
+    return (
+      <div className="skeleton-movie-card skeleton-movie-card-overlay">
+        <Skeleton height="642px" borderRadius="8px" />
+        <div className="skeleton-overlay-content">
+          <Skeleton width="60%" height="32px" style={{ marginBottom: "12px" }} />
+          <Skeleton width="80%" height="20px" style={{ marginBottom: "8px" }} />
+          <Skeleton width="40%" height="16px" />
+        </div>
+      </div>
+    );
+  }
+
+  if (layout === "left") {
+    return (
+      <div className="skeleton-movie-card skeleton-movie-card-left">
+        <Skeleton width="80px" height="120px" borderRadius="4px" />
+        <div className="skeleton-left-content">
+          <Skeleton width="24px" height="24px" borderRadius="50%" />
+        </div>
+      </div>
+    );
+  }
+
+  if (layout === "none") {
+    return (
+      <div className="skeleton-movie-card skeleton-movie-card-none">
+        <Skeleton height="164px" borderRadius="8px" />
+      </div>
+    );
+  }
+
+  // default: top layout
+  return (
+    <div className="skeleton-movie-card skeleton-movie-card-top">
+      <Skeleton height="289px" borderRadius="8px" />
+      <div className="skeleton-top-content">
+        <Skeleton width="90%" height="20px" style={{ marginBottom: "8px" }} />
+        <Skeleton width="70%" height="16px" />
+      </div>
+    </div>
+  );
+});
+
+// 캐러셀용 스켈레톤
+const CarouselSkeleton: React.FC<{ 
+  height: number; 
+  articleWidth: number; 
+  layout?: "overlay" | "top" | "left" | "none";
+  count?: number;
+}> = memo(({ height, articleWidth, layout = "top", count = 5 }) => {
+  return (
+    <div className="skeleton-carousel" style={{ height: `${height}px` }}>
+      <div className="skeleton-carousel-track" style={{ width: `${articleWidth * count}px` }}>
+        {Array.from({ length: count }, (_, index) => (
+          <div
+            key={index}
+            className="skeleton-carousel-article"
+            style={{ width: `${articleWidth}px` }}
+          >
+            <MovieCardSkeleton layout={layout} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+});
+
+// 페이지 전체 로딩용 스켈레톤
+const PageSkeleton: React.FC = memo(() => {
+  return (
+    <div className="skeleton-page">
+      {/* 탭 스켈레톤 */}
+      <div className="skeleton-tabs">
+        {Array.from({ length: 5 }, (_, index) => (
+          <Skeleton key={index} width="120px" height="40px" borderRadius="20px" />
+        ))}
+      </div>
+
+      {/* 메인 캐러셀 스켈레톤 */}
+      <section style={{ marginBottom: "40px" }}>
+        <CarouselSkeleton height={642} articleWidth={1140} layout="overlay" count={3} />
+      </section>
+
+      {/* 추천 캐러셀 스켈레톤 */}
+      <section style={{ marginBottom: "40px" }}>
+        <CarouselSkeleton height={289} articleWidth={421} layout="top" count={4} />
+      </section>
+
+      {/* Top 20 캐러셀 스켈레톤 */}
+      <section style={{ marginBottom: "40px" }}>
+        <Skeleton width="200px" height="28px" style={{ marginBottom: "16px" }} />
+        <CarouselSkeleton height={200} articleWidth={400} layout="left" count={5} />
+      </section>
+
+      {/* 새로 올라온 콘텐츠 캐러셀 스켈레톤 */}
+      <section style={{ marginBottom: "40px" }}>
+        <Skeleton width="180px" height="28px" style={{ marginBottom: "16px" }} />
+        <CarouselSkeleton height={164} articleWidth={290} layout="none" count={6} />
+      </section>
+    </div>
+  );
+});
+
+// 상세 페이지용 스켈레톤
+const DetailPageSkeleton: React.FC = memo(() => {
+  return (
+    <div className="skeleton-detail-page">
+      <div className="skeleton-detail-header">
+        <div className="skeleton-detail-info">
+          {/* 영화 제목 */}
+          <div className="skeleton-detail-title">
+            <Skeleton width="80%" height="48px" style={{ marginBottom: "16px" }} />
+          </div>
+          
+          {/* 영화 메타 정보 */}
+          <div className="skeleton-detail-meta">
+            <Skeleton width="80px" height="20px" />
+            <Skeleton width="60px" height="20px" />
+            <Skeleton width="100px" height="20px" />
+          </div>
+          
+          {/* 영화 개요 */}
+          <div className="skeleton-detail-overview">
+            <Skeleton width="100%" height="66px" style={{ marginTop: "16px" }} />
+          </div>
+          
+          {/* 평점 정보 */}
+          <div className="skeleton-detail-rating">
+            <div className="skeleton-vote-average">
+              <Skeleton width="60px" height="44px" />
+              <Skeleton width="80px" height="20px" style={{ marginTop: "4px" }} />
+            </div>
+            <div className="skeleton-vote-count">
+              <Skeleton width="80px" height="44px" />
+              <Skeleton width="60px" height="20px" style={{ marginTop: "4px" }} />
+            </div>
+          </div>
+          
+          {/* 액션 버튼들 */}
+          <div className="skeleton-detail-actions">
+            <div className="skeleton-purchase-section">
+              <Skeleton width="120px" height="40px" style={{ marginRight: "10px" }} />
+              <Skeleton width="120px" height="40px" />
+            </div>
+            <div className="skeleton-evaluation-section">
+              {Array.from({ length: 4 }, (_, index) => (
+                <Skeleton key={index} width="120px" height="78px" borderRadius="6px" />
+              ))}
+            </div>
+          </div>
+        </div>
+        
+        <div className="skeleton-detail-image">
+          <Skeleton height="100%" borderRadius="8px" />
+        </div>
+      </div>
+
+      <div className="skeleton-detail-sections">
+        {/* 관련 콘텐츠 섹션 */}
+        <section className="skeleton-section">
+          <Skeleton width="150px" height="24px" style={{ marginBottom: "20px" }} />
+          <div className="skeleton-collection">
+            <Skeleton width="200px" height="288px" borderRadius="4px" />
+          </div>
+        </section>
+
+        {/* 관련 동영상 섹션 */}
+        <section className="skeleton-section">
+          <Skeleton width="150px" height="24px" style={{ marginBottom: "20px" }} />
+          <div className="skeleton-videos">
+            {Array.from({ length: 4 }, (_, index) => (
+              <div key={index} className="skeleton-video-item">
+                <Skeleton width="100%" height="20px" style={{ marginBottom: "8px" }} />
+                <Skeleton width="60px" height="16px" />
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* 감독/출연 섹션 */}
+        <section className="skeleton-section">
+          <Skeleton width="150px" height="24px" style={{ marginBottom: "20px" }} />
+          <div className="skeleton-members">
+            {Array.from({ length: 6 }, (_, index) => (
+              <div key={index} className="skeleton-member-item">
+                <Skeleton width="50px" height="50px" borderRadius="50%" />
+                <div className="skeleton-member-info">
+                  <Skeleton width="100px" height="22px" style={{ marginBottom: "2px" }} />
+                  <Skeleton width="80px" height="18px" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* 리뷰 섹션 */}
+        <section className="skeleton-section">
+          <Skeleton width="200px" height="24px" style={{ marginBottom: "20px" }} />
+          <div className="skeleton-reviews">
+            {Array.from({ length: 3 }, (_, index) => (
+              <div key={index} className="skeleton-review-item">
+                <Skeleton width="38px" height="38px" borderRadius="50%" />
+                <div className="skeleton-review-content">
+                  <Skeleton width="120px" height="22px" style={{ marginBottom: "8px" }} />
+                  <Skeleton width="100%" height="60px" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+});
+
+// 검색 홈 페이지용 스켈레톤
+const SearchHomePageSkeleton: React.FC = memo(() => {
+  return (
+    <div className="skeleton-search-home">
+      {/* 인기 검색어 섹션 */}
+      <section className="skeleton-popular-keyword">
+        <div className="skeleton-popular-header">
+          <Skeleton width="200px" height="32px" style={{ marginBottom: "24px" }} />
+        </div>
+        <div className="skeleton-popular-content">
+          <div className="skeleton-trending-list">
+            <div className="skeleton-tabs">
+              {Array.from({ length: 5 }, (_, index) => (
+                <Skeleton key={index} width="100px" height="36px" borderRadius="18px" />
+              ))}
+            </div>
+            <div className="skeleton-trending-items">
+              {Array.from({ length: 10 }, (_, index) => (
+                <div key={index} className="skeleton-trending-item">
+                  <Skeleton width="24px" height="24px" borderRadius="50%" />
+                  <Skeleton width="200px" height="20px" />
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="skeleton-background-img">
+            <Skeleton height="400px" borderRadius="8px" />
+          </div>
+        </div>
+      </section>
+
+      {/* 장르별 영화 섹션 */}
+      <section className="skeleton-category">
+        <div className="skeleton-category-header">
+          <Skeleton width="150px" height="28px" style={{ marginBottom: "8px" }} />
+          <Skeleton width="300px" height="20px" />
+        </div>
+        <CarouselSkeleton height={180} articleWidth={319} layout="overlay" count={4} />
+      </section>
+    </div>
+  );
+});
+
+// 검색 결과 페이지용 스켈레톤
+const SearchResultPageSkeleton: React.FC = memo(() => {
+  return (
+    <div className="skeleton-search-result">
+      {/* 검색 결과 헤더 */}
+      <div className="skeleton-search-header">
+        <Skeleton width="300px" height="32px" style={{ marginBottom: "8px" }} />
+        <Skeleton width="100px" height="20px" />
+      </div>
+
+      {/* 검색 결과 그리드 */}
+      <div className="skeleton-search-grid">
+        {Array.from({ length: 12 }, (_, index) => (
+          <div key={index} className="skeleton-search-item">
+            <Skeleton height="200px" borderRadius="8px" />
+            <Skeleton width="80%" height="16px" style={{ marginTop: "8px" }} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+});
+
+const SkeletonComponents = {
+  Skeleton,
+  MovieCardSkeleton,
+  CarouselSkeleton,
+  PageSkeleton,
+  DetailPageSkeleton,
+  SearchHomePageSkeleton,
+  SearchResultPageSkeleton,
+} as const;
+
+export default SkeletonComponents;
+export { 
+  Skeleton, 
+  MovieCardSkeleton, 
+  CarouselSkeleton, 
+  PageSkeleton, 
+  DetailPageSkeleton,
+  SearchHomePageSkeleton,
+  SearchResultPageSkeleton,
+};

--- a/src/components/Status.tsx
+++ b/src/components/Status.tsx
@@ -1,5 +1,6 @@
 import "@/styles/Status.css";
 import React from "react";
+import { PageSkeleton, DetailPageSkeleton, SearchHomePageSkeleton, SearchResultPageSkeleton } from "./Skeleton";
 
 type ErrorProps = {
   message?: string;
@@ -13,6 +14,22 @@ const Loading: React.FC = () => {
       <div className="status-text">로딩중...</div>
     </div>
   );
+};
+
+const PageLoading: React.FC = () => {
+  return <PageSkeleton />;
+};
+
+const DetailPageLoading: React.FC = () => {
+  return <DetailPageSkeleton />;
+};
+
+const SearchHomePageLoading: React.FC = () => {
+  return <SearchHomePageSkeleton />;
+};
+
+const SearchResultPageLoading: React.FC = () => {
+  return <SearchResultPageSkeleton />;
 };
 
 const ErrorState: React.FC<ErrorProps> = ({ message, retry }) => {
@@ -29,7 +46,21 @@ const ErrorState: React.FC<ErrorProps> = ({ message, retry }) => {
   );
 };
 
-const Status = { Loading, ErrorState } as const;
+const Status = { 
+  Loading, 
+  PageLoading, 
+  DetailPageLoading, 
+  SearchHomePageLoading,
+  SearchResultPageLoading,
+  ErrorState 
+} as const;
 
 export default Status;
-export { Loading, ErrorState };
+export { 
+  Loading, 
+  PageLoading, 
+  DetailPageLoading, 
+  SearchHomePageLoading,
+  SearchResultPageLoading,
+  ErrorState 
+};

--- a/src/hooks/useMovieDetail.tsx
+++ b/src/hooks/useMovieDetail.tsx
@@ -8,27 +8,49 @@ const useMovieDetail = () => {
   let params = useParams();
 
   // URL에서 movieId 추출
-  const movieId = params.id!;
+  const movieId = params.id;
 
-  const  { detailQuery,  reviewsQuery} = movieDetailQuery(movieId)
+  // movieId가 없으면 에러 처리
+  if (!movieId) {
+    console.error("Movie ID가 URL에서 찾을 수 없습니다.");
+    return {
+      movieData: null,
+      reviews: [],
+      getReleaseYear: () => 0,
+      changeTimeFormat: () => "",
+    };
+  }
 
-  
-  const getReleaseYear = (date: string): number => {
-    const newDay = dayjs(date);
-    return newDay.year();
-  };
+  try {
+    const { detailQuery, reviewsQuery } = movieDetailQuery(movieId);
 
-  const changeTimeFormat = (time: number): string => {
-    const formattedTime = dayjs.duration(time, "minute").format("HH시간 mm분");
-    return formattedTime;
-  };
+    const getReleaseYear = (date: string): number => {
+      if (!date) return 0;
+      const newDay = dayjs(date);
+      return newDay.year();
+    };
 
-  return {
-    movieData: detailQuery.data,
-    reviews: reviewsQuery.data,
-    getReleaseYear,
-    changeTimeFormat,
-  };
+    const changeTimeFormat = (time: number): string => {
+      if (!time) return "0분";
+      const formattedTime = dayjs.duration(time, "minute").format("HH시간 mm분");
+      return formattedTime;
+    };
+
+    return {
+      movieData: detailQuery.data,
+      reviews: reviewsQuery.data || [],
+      getReleaseYear,
+      changeTimeFormat,
+    };
+  } catch (error) {
+    console.error("영화 상세 정보를 가져오는 중 오류 발생:", error);
+    return {
+      movieData: null,
+      reviews: [],
+      getReleaseYear: () => 0,
+      changeTimeFormat: () => "",
+    };
+  }
 };
 
 export default useMovieDetail;

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -14,12 +14,29 @@ import "@/styles/Detail.css";
 
 
 const DetailPageContent = () => {
-  const { movieData, reviews,  getReleaseYear, changeTimeFormat } = useMovieDetail();
+  const { movieData, reviews, getReleaseYear, changeTimeFormat } = useMovieDetail();
 
+  // 로딩 상태 처리
   if (!movieData) {
     return (
       <div className="detail-page">
-        <div className="no-data">데이터를 찾을 수 없습니다.</div>
+        <div className="no-data">
+          <h2>영화 정보를 불러오는 중...</h2>
+          <p>잠시만 기다려주세요.</p>
+        </div>
+      </div>
+    );
+  }
+
+  // 에러 상태 처리
+  if (movieData && !movieData.id) {
+    return (
+      <div className="detail-page">
+        <div className="no-data">
+          <h2>영화 정보를 찾을 수 없습니다</h2>
+          <p>요청하신 영화의 정보가 존재하지 않습니다.</p>
+          <button onClick={() => window.history.back()}>이전 페이지로</button>
+        </div>
       </div>
     );
   }
@@ -185,7 +202,7 @@ const DetailPageContent = () => {
 const DetailPage = () => {
   return (
     <AppErrorBoundary>
-      <React.Suspense fallback={<Status.Loading />}>
+      <React.Suspense fallback={<Status.DetailPageLoading />}>
         <DetailPageContent />
       </React.Suspense>
     </AppErrorBoundary>

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -95,7 +95,7 @@ const ListPageContent = () => {
 const ListPage = () => {
   return (
     <AppErrorBoundary>
-      <React.Suspense fallback={<Status.Loading />}>
+      <React.Suspense fallback={<Status.PageLoading />}>
         <ListPageContent />
       </React.Suspense>
     </AppErrorBoundary>

--- a/src/pages/SearchHomePage.tsx
+++ b/src/pages/SearchHomePage.tsx
@@ -94,7 +94,7 @@ const SearchHomePageContent = () => {
 const SearchHomePage = () => {
   return (
     <AppErrorBoundary>
-      <React.Suspense fallback={<Status.Loading />}>
+      <React.Suspense fallback={<Status.SearchHomePageLoading />}>
         <SearchHomePageContent />
       </React.Suspense>
     </AppErrorBoundary>

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -89,7 +89,7 @@ const SearchResultPageContent = () => {
 const SearchResultPage = () => {
   return (
     <AppErrorBoundary>
-      <React.Suspense fallback={<Status.Loading />}>
+      <React.Suspense fallback={<Status.SearchResultPageLoading />}>
         <SearchResultPageContent />
       </React.Suspense>
     </AppErrorBoundary>

--- a/src/queries/detail/movieDetailQuery.ts
+++ b/src/queries/detail/movieDetailQuery.ts
@@ -1,21 +1,25 @@
-import {  useSuspenseQueries } from "@tanstack/react-query"
+import { useSuspenseQueries } from "@tanstack/react-query"
 import { movieDetailKeys } from "./queryKeys"
 import { fetchMovieDetail, fetchMovieReviews } from "@/utils/api"
 
-export const movieDetailQuery = (movidId: string) => {
+export const movieDetailQuery = (movieId: string) => {
     const results = useSuspenseQueries({
         queries: [
             {
-                queryKey: movieDetailKeys.detail(movidId),
-                queryFn: () => fetchMovieDetail(movidId),
+                queryKey: movieDetailKeys.detail(movieId),
+                queryFn: () => fetchMovieDetail(movieId),
+                retry: 2,
+                retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
             },
             {
-                queryKey: movieDetailKeys.reviews(movidId),
-                queryFn: () => fetchMovieReviews(movidId),
+                queryKey: movieDetailKeys.reviews(movieId),
+                queryFn: () => fetchMovieReviews(movieId),
+                retry: 1,
+                retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
             }
         ]
     })
     const [detailQuery, reviewsQuery] = results;
 
-  return {  detailQuery,  reviewsQuery };
+  return { detailQuery, reviewsQuery };
 }

--- a/src/styles/Detail.css
+++ b/src/styles/Detail.css
@@ -377,3 +377,68 @@
   overflow: hidden;
   word-break: break-all;
 }
+
+/* 에러 상태 스타일 */
+.no-data {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+  text-align: center;
+  color: white;
+  padding: 40px;
+}
+
+.no-data h2 {
+  font-size: 24px;
+  margin-bottom: 16px;
+  color: #ffffff;
+}
+
+.no-data p {
+  font-size: 16px;
+  margin-bottom: 24px;
+  color: #84868d;
+  line-height: 1.5;
+}
+
+.no-data button {
+  background-color: #f82f62;
+  color: white;
+  border: none;
+  padding: 12px 24px;
+  border-radius: 6px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.no-data button:hover {
+  background-color: #d91e4f;
+}
+
+/* 로딩 상태 스타일 */
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+  color: white;
+}
+
+.loading::after {
+  content: '';
+  width: 20px;
+  height: 20px;
+  border: 2px solid #f82f62;
+  border-top: 2px solid transparent;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-left: 12px;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/src/styles/Skeleton.css
+++ b/src/styles/Skeleton.css
@@ -1,0 +1,439 @@
+/* 기본 스켈레톤 애니메이션 - 성능 최적화 */
+.skeleton {
+  background: linear-gradient(90deg, #2a2a2a 25%, #3a3a3a 50%, #2a2a2a 75%);
+  background-size: 200% 100%;
+  animation: skeleton-loading 1.5s ease-in-out infinite;
+  display: block;
+  will-change: background-position;
+  transform: translateZ(0); /* GPU 가속 활성화 */
+}
+
+@keyframes skeleton-loading {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* 영화 카드 스켈레톤 */
+.skeleton-movie-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.skeleton-movie-card-overlay {
+  position: relative;
+  height: 642px;
+}
+
+.skeleton-overlay-content {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 24px;
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.8));
+}
+
+.skeleton-movie-card-top {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.skeleton-top-content {
+  padding: 0 8px;
+}
+
+.skeleton-movie-card-left {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  height: 120px;
+}
+
+.skeleton-left-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.skeleton-movie-card-none {
+  height: 164px;
+}
+
+/* 캐러셀 스켈레톤 */
+.skeleton-carousel {
+  position: relative;
+  overflow: hidden;
+  border-radius: 8px;
+}
+
+.skeleton-carousel-track {
+  display: flex;
+  gap: 16px;
+  height: 100%;
+}
+
+.skeleton-carousel-article {
+  flex-shrink: 0;
+  height: 100%;
+}
+
+/* 페이지 스켈레톤 */
+.skeleton-page {
+  padding: 24px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.skeleton-tabs {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 32px;
+  padding: 0 16px;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 768px) {
+  .skeleton-page {
+    padding: 16px;
+  }
+  
+  .skeleton-tabs {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  
+  .skeleton-carousel-track {
+    gap: 12px;
+  }
+  
+  .skeleton-overlay-content {
+    padding: 16px;
+  }
+}
+
+/* 다크 모드 지원 */
+@media (prefers-color-scheme: dark) {
+  .skeleton {
+    background: linear-gradient(90deg, #1a1a1a 25%, #2a2a2a 50%, #1a1a1a 75%);
+    background-size: 200% 100%;
+  }
+}
+
+/* 접근성 개선 */
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+    background: #2a2a2a;
+  }
+}
+
+/* 고대비 모드 지원 */
+@media (prefers-contrast: high) {
+  .skeleton {
+    background: #000000;
+    border: 1px solid #ffffff;
+  }
+}
+
+/* 상세 페이지 스켈레톤 - 기존 Detail.css와 충돌 방지 */
+.skeleton-detail-page {
+  position: relative;
+  background: linear-gradient(90deg, rgba(89, 89, 89, 1) 0%, rgba(0, 0, 0, 1) 45%, rgba(77, 77, 77, 1) 100%);
+  height: 646px;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 40px 0 0 0;
+  margin-bottom: 32px;
+}
+
+.skeleton-detail-header {
+  display: flex;
+  flex-direction: row;
+  gap: 32px;
+  align-items: flex-start;
+  padding: 0 40px;
+  height: 100%;
+}
+
+.skeleton-detail-info {
+  min-width: 25em;
+  max-width: 37.25em;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  height: 100%;
+  padding-top: 40px;
+}
+
+.skeleton-detail-meta {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  min-height: 22px;
+  gap: 4px;
+  margin-bottom: 16px;
+}
+
+.skeleton-detail-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  justify-content: flex-end;
+  margin-top: 24px;
+}
+
+.skeleton-detail-title {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+.skeleton-detail-overview {
+  position: relative;
+}
+
+.skeleton-detail-rating {
+  display: flex;
+  align-items: center;
+  min-height: 92px;
+  justify-content: flex-start;
+  gap: 70px;
+  margin: 24px 0;
+}
+
+.skeleton-vote-average,
+.skeleton-vote-count {
+  display: flex;
+  flex-direction: column;
+}
+
+.skeleton-purchase-section {
+  display: flex;
+  gap: 10px;
+}
+
+.skeleton-evaluation-section {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  align-items: stretch;
+  justify-content: flex-start;
+}
+
+.skeleton-detail-image {
+  flex: 1;
+  min-height: 270px;
+  position: relative;
+  border-radius: 8px;
+  overflow: hidden;
+  display: block;
+  margin-top: 40px;
+}
+
+.skeleton-detail-sections {
+  padding: 0 40px;
+  background: rgba(0, 0, 0, 0.9);
+}
+
+.skeleton-section {
+  margin-top: 40px;
+  margin-bottom: 32px;
+}
+
+.skeleton-collection {
+  position: relative;
+  z-index: 0;
+  height: 288px;
+  display: flex;
+  gap: 16px;
+}
+
+.skeleton-videos {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.skeleton-video-item {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.skeleton-members {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px 40px;
+  margin-top: 20px;
+}
+
+.skeleton-member-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.skeleton-member-info {
+  flex: 1;
+}
+
+.skeleton-reviews {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.skeleton-review-item {
+  display: flex;
+  align-items: flex-start;
+  padding: 8px 0;
+  gap: 12px;
+}
+
+.skeleton-review-content {
+  flex: 1;
+}
+
+/* 상세 페이지 반응형 */
+@media (max-width: 768px) {
+  .skeleton-detail-page {
+    height: auto;
+    padding: 20px 0 0 0;
+  }
+  
+  .skeleton-detail-header {
+    flex-direction: column;
+    gap: 24px;
+    padding: 0 20px;
+  }
+  
+  .skeleton-detail-info {
+    min-width: auto;
+    max-width: none;
+    padding-top: 20px;
+  }
+  
+  .skeleton-detail-image {
+    width: 100%;
+    min-height: 200px;
+    margin-top: 20px;
+  }
+  
+  .skeleton-detail-actions {
+    flex-direction: column;
+  }
+  
+  .skeleton-purchase-section {
+    flex-direction: column;
+  }
+  
+  .skeleton-evaluation-section {
+    flex-wrap: wrap;
+  }
+  
+  .skeleton-members {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+  
+  .skeleton-videos {
+    grid-template-columns: 1fr;
+  }
+  
+  .skeleton-detail-sections {
+    padding: 0 20px;
+  }
+}
+
+/* 검색 페이지 스켈레톤 */
+.skeleton-search-home {
+  padding: 24px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.skeleton-popular-keyword {
+  margin-bottom: 48px;
+}
+
+.skeleton-popular-content {
+  display: flex;
+  gap: 32px;
+}
+
+.skeleton-trending-list {
+  flex: 1;
+}
+
+.skeleton-trending-items {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.skeleton-trending-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.skeleton-background-img {
+  width: 400px;
+  flex-shrink: 0;
+}
+
+.skeleton-category {
+  margin-bottom: 32px;
+}
+
+.skeleton-category-header {
+  margin-bottom: 24px;
+}
+
+.skeleton-search-result {
+  padding: 24px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.skeleton-search-header {
+  margin-bottom: 32px;
+}
+
+.skeleton-search-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.skeleton-search-item {
+  display: flex;
+  flex-direction: column;
+}
+
+/* 검색 페이지 반응형 */
+@media (max-width: 768px) {
+  .skeleton-popular-content {
+    flex-direction: column;
+    gap: 24px;
+  }
+  
+  .skeleton-background-img {
+    width: 100%;
+  }
+  
+  .skeleton-search-grid {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 12px;
+  }
+}

--- a/src/types/Movie.ts
+++ b/src/types/Movie.ts
@@ -132,6 +132,7 @@ export interface Reviews {
 
 // 컴포넌트에서 사용할 정리된 데이터 타입
 export interface MovieData {
+  id: number;
   title: string;
   releaseDate: string;
   runtime: number | null;

--- a/src/utils/api.tsx
+++ b/src/utils/api.tsx
@@ -20,12 +20,25 @@ export const fetchNowPlayingMovieList = () =>
 export const fetchMovieDetail = (movieId: string) => 
   instance
     .get(`/movie/${movieId}?append_to_response=credits,videos,belongs_to_collection&language=ko-KR`)
-    .then((response) => transformMovieData(response.data));
+    .then((response) => {
+      if (!response.data || !response.data.id) {
+        throw new Error(`영화 ID ${movieId}에 대한 데이터를 찾을 수 없습니다.`);
+      }
+      return transformMovieData(response.data);
+    })
+    .catch((error) => {
+      console.error(`영화 상세 정보 가져오기 실패 (ID: ${movieId}):`, error);
+      throw error;
+    });
 
 export const fetchMovieReviews = (movieId: string) => 
   instance
     .get(`/movie/${movieId}/reviews?language=en-US&page=1`)
-    .then((response) => response.data);
+    .then((response) => response.data || { results: [] })
+    .catch((error) => {
+      console.error(`영화 리뷰 가져오기 실패 (ID: ${movieId}):`, error);
+      return { results: [] }; // 리뷰는 필수가 아니므로 빈 배열 반환
+    });
 
 export const fetchTodayTrendingMovie = () => 
   instance

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -21,6 +21,7 @@ export const transformMovieData = (response: any): MovieData => {
   const director = response.credits?.crew?.find((member: any) => member.job === "Director") || null;
 
   return {
+    id: response.id,
     title: response.title,
     releaseDate: response.release_date,
     runtime: response.runtime,


### PR DESCRIPTION
## 개요 (Summary)
여러 페이지에 Skeleton UI를 적용하여 로딩 상태에서 사용자 경험을 개선했습니다.  
빈 화면 대신 콘텐츠 구조와 유사한 플레이스홀더를 표시하도록 변경했습니다.

---

## 변경 사항 (Changes)
- 다양한 Skeleton 컴포넌트 추가 (MovieCardSkeleton, CarouselSkeleton, PageSkeleton, DetailPageSkeleton, SearchHomePageSkeleton, SearchResultPageSkeleton)
- `Status.tsx` 컴포넌트 개선: 로딩 상태에 따라 페이지별 Skeleton 컴포넌트 표시
- `Skeleton.css` 등 스타일 추가 → Skeleton UI 표시용 스타일 정의
- `DetailPage`, `ListPage`, `SearchHomePage`, `SearchResultPage` 에 Skeleton UI 적용
- 타입 정의 및 유틸리티 일부 수정 (`Movie.ts`, `transform.ts` 등)


---

## 관련 이슈 (Related Issues)
- Related to #35
<img width="979" height="731" alt="스크린샷 2025-09-12 170618" src="https://github.com/user-attachments/assets/bd7742a2-dfeb-4eae-b4bb-7162ddc7a8d6" />

