### PR TITLE
package.json에서 "type": "module" 항목을 제거

### DIFF
--- a/apps/watcha_clone_coding/package.json
+++ b/apps/watcha_clone_coding/package.json
@@ -1,7 +1,6 @@
 {
   "name": "watcha_clone_coding",
   "version": "1.0.0",
-  "type": "module",
   "description": "\"# watcha_clone_coding\"",
   "main": "index.js",
   "packageManager": "pnpm@10.15.1",


### PR DESCRIPTION
## 개요 (Summary)
`package.json`에서 `"type": "module"` 항목을 제거하여 ES Modules와 CommonJS 간의 호환성 문제를 해결했습니다.

---

## 변경 사항 (Changes)
- `package.json`에서 `"type": "module"` 제거
- ES Modules와 CommonJS 간의 호환성 문제 해결
- 빌드 및 실행 환경에서의 안정성 강화

---

## 관련 이슈 (Related Issues)
- Related to #51

