### PR TITLE
CSS 파일 복사 로직 추가 및 package.json에서 type: module 복원 처리

### DIFF
--- a/.github/workflows/deploy-optimized.yml
+++ b/.github/workflows/deploy-optimized.yml
@@ -48,11 +48,29 @@ jobs:
           echo "=== 워크스페이스 패키지들 빌드 ==="
           pnpm --filter @watcha/carousel build
           
+          # CSS 파일 복사 (TypeScript가 복사하지 않는 경우)
+          if [ -d "packages/carousel/src/styles" ]; then
+            echo "=== CSS 파일 복사 ==="
+            mkdir -p packages/carousel/dist/src/styles
+            cp -r packages/carousel/src/styles/* packages/carousel/dist/src/styles/ || echo "CSS 파일 복사 실패"
+          fi
+          
       - name: Run type check
         run: pnpm type-check
         
       - name: Build for production
-        run: pnpm build:production
+        run: |
+          # ES Modules 이슈 해결을 위한 임시 조치
+          cd apps/watcha_clone_coding
+          
+          # package.json에서 type: module 임시 제거
+          sed -i 's/"type": "module",//g' package.json
+          
+          # 빌드 실행
+          pnpm build:production
+          
+          # type: module 복원
+          sed -i 's/"version": "1.0.0",/"version": "1.0.0",\n  "type": "module",/g' package.json
         
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## 개요 (Summary)
워크스페이스 패키지 빌드 과정에서 CSS 파일이 누락되는 문제를 해결하기 위해  
CSS 파일 복사 로직을 추가했습니다. 또한 빌드 후 `package.json`의 `"type": "module"` 항목을 복원하여  
ESM과 CommonJS 간의 호환성을 유지했습니다.

---

## 변경 사항 (Changes)
- 워크스페이스 패키지 빌드 시 CSS 파일 복사 로직 추가
- 빌드 후 `package.json`의 `"type": "module"` 항목 자동 복원 처리
- ESM 및 CommonJS 환경 간의 호환성 유지
- 빌드 파이프라인 안정성 및 사용성 개선

---

## 관련 이슈 (Related Issues)
- Related to #51

