### PR TITLE
tsconfig.json에서 svgr/webpack 타입 정의 제거하여 구성 최적화

### DIFF
--- a/apps/watcha_clone_coding/tsconfig.json
+++ b/apps/watcha_clone_coding/tsconfig.json
@@ -9,7 +9,6 @@
       "@/*": ["./src/*"],
       "@watcha/carousel": ["../../packages/carousel"]
     },
-    "types": ["svgr/webpack"],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## 개요 (Summary)
`tsconfig.json`에서 불필요한 **svgr/webpack 타입 정의**를 제거하여 타입 구성과 빌드 환경을 최적화했습니다.

---

## 변경 사항 (Changes)
- `tsconfig.json`에서 `svgr/webpack` 타입 정의 제거  

---

## 관련 이슈 (Related Issues)
- Related to #71

