### PR TITLE
컬렉션 포스터 이미지에 대한 alt 텍스트를 포함하도록 영화 세부 정보 페이지를 업데이트합니다.

### DIFF
--- a/apps/watcha_clone_coding/src/pages/movie/[id].tsx
+++ b/apps/watcha_clone_coding/src/pages/movie/[id].tsx
@@ -115,7 +115,7 @@ const DetailPageContent: React.FC = () => {
           {movieData.collection && (
             <ul className="collection-list">
               <li className="collection-item">
-                <Image src={buildImageUrl(movieData.collection.poster_path)} />
+                <Image src={buildImageUrl(movieData.collection.poster_path)} alt={movieData.collection.name} />
               </li>
             </ul>
           )}


### PR DESCRIPTION
## 개요 (Summary)
영화 상세 정보 페이지에서 접근성과 SEO 향상을 위해 **컬렉션 포스터 이미지에 `alt` 텍스트를 추가**했습니다.  
이를 통해 스크린 리더 사용 시 콘텐츠 인식이 개선되고, 검색 엔진 최적화에 도움이 됩니다.

---

## 변경 사항 (Changes)
- 영화 상세 페이지의 컬렉션 포스터 이미지에 `alt` 속성 추가  
- 접근성(Accessibility) 및 SEO 품질 개선  

---

## 관련 이슈 (Related Issues)
- Related to #71 

