### PR TITLE
메인 슬라이드 이미지에 priority 적용

### DIFF
--- a/apps/watcha_clone_coding/src/components/MovieCard.tsx
+++ b/apps/watcha_clone_coding/src/components/MovieCard.tsx
@@ -15,6 +15,7 @@ const MovieCard = (props: MovieCardProps) => {
             fill
             sizes="(max-width: 768px) 100vw, 500px"
             style={{ objectFit: 'cover' }}
+            priority={props.priority}
           />
         </div>
         <div className={`slider-content slider-content-${props.layout}`}>

--- a/apps/watcha_clone_coding/src/pages/index.tsx
+++ b/apps/watcha_clone_coding/src/pages/index.tsx
@@ -41,7 +41,7 @@ const ListPageContent = () => {
           <Carousel.Track articleWidth={1140}>
             <Carousel.Article articleWidth={1140} layout="overlay">
               {(slide: any) => {
-                return <MovieCard slide={slide as CarouselProps} layout="overlay" type="movie" />;
+                return <MovieCard slide={slide as CarouselProps} layout="overlay" type="movie" priority={true} />;
               }}
             </Carousel.Article>
           </Carousel.Track>

--- a/apps/watcha_clone_coding/src/types/Carousel.ts
+++ b/apps/watcha_clone_coding/src/types/Carousel.ts
@@ -10,6 +10,11 @@ export type CarouselProps = {
   onClick?: () => void;
 };
 
-export type MovieCardProps = { type: 'movie'; slide: CarouselProps; layout: 'overlay' | 'top' | 'left' | 'none' };
+export type MovieCardProps = {
+  type: 'movie';
+  slide: CarouselProps;
+  layout: 'overlay' | 'top' | 'left' | 'none';
+  priority?: boolean;
+};
 
 export type GenredCardProps = { type: 'genres'; slide: Genre; layout: 'overlay' | 'top' | 'left' | 'none' };


### PR DESCRIPTION
## 개요 (Summary)
페이지 로딩 성능 향상과 사용자 경험 개선을 위해  
**메인 슬라이드 이미지에 `priority` 속성을 적용**했습니다.  
이를 통해 초기 렌더링 시 중요한 이미지가 더 빠르게 로드되도록 최적화했습니다.

---

## 변경 사항 (Changes)
- `MovieCard` 컴포넌트에 `priority` 속성 추가 및 전달 가능하도록 수정  
- `ListPageContent`에서 메인 슬라이드 이미지에 `priority` 속성 전달  
- 주요 이미지의 로드 우선순위 향상으로 초기 렌더링 속도 개선  

---

## 관련 이슈 (Related Issues)
- Related to #71 

