### PR TITLE
불필요한 `'use client'` 지시문 제거 및 이미지 렌더링 개선

### DIFF
--- a/apps/watcha_clone_coding/src/pages/SearchHomePage.tsx
+++ b/apps/watcha_clone_coding/src/pages/SearchHomePage.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Carousel } from '@watcha/carousel';
 import Head from 'next/head';
 import Image from 'next/image';
@@ -64,6 +62,9 @@ const SearchHomePageContent = () => {
                 <Image
                   src={buildImageUrl(trendingQuery.data[highlightedIndex].backdrop_path)}
                   alt={trendingQuery.data[highlightedIndex].title}
+                  width={1280}
+                  height={720}
+                  style={{ width: '100%', height: '100%', objectFit: 'cover' }}
                 />
               )}
             </div>

--- a/apps/watcha_clone_coding/src/pages/SearchResultPage.tsx
+++ b/apps/watcha_clone_coding/src/pages/SearchResultPage.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Head from 'next/head';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -63,7 +61,13 @@ const SearchResultPageContent = () => {
               {resultData.map((movie) => (
                 <li className="search-result-item" key={movie.id}>
                   <Link href={`/movie/${movie.id}`}>
-                    <Image src={buildImageUrl(movie.image)} alt={movie.title} />
+                    <Image
+                      src={buildImageUrl(movie.image)}
+                      alt={movie.title}
+                      width={300}
+                      height={450}
+                      style={{ width: '100%', height: 'auto', objectFit: 'cover' }}
+                    />
                     <div className="movie-info">
                       <span>{movie.title}</span>
                     </div>

--- a/apps/watcha_clone_coding/src/pages/index.tsx
+++ b/apps/watcha_clone_coding/src/pages/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Carousel } from '@watcha/carousel';
 import Head from 'next/head';
 import React from 'react';

--- a/apps/watcha_clone_coding/src/pages/movie/[id].tsx
+++ b/apps/watcha_clone_coding/src/pages/movie/[id].tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Head from 'next/head';
 import Image from 'next/image';
 import React from 'react';


### PR DESCRIPTION
## 개요 (Summary)
여러 페이지에서 **사용되지 않는 `'use client'` 지시문을 제거**하고,  
`SearchHomePage` 및 `SearchResultPage` 구성 요소의 이미지 렌더링 품질을 개선했습니다.  
이미지에 `width`, `height`, `objectFit` 스타일을 지정하여 **더 나은 시각적 일관성**을 제공합니다.

---

## 변경 사항 (Changes)
- 불필요한 `'use client'` 지시문 제거 (여러 페이지에서 적용)  
- `SearchHomePage`, `SearchResultPage` 이미지 렌더링 개선  
  - `width`, `height`, `objectFit` 속성 추가  
  - 이미지 비율 유지 및 시각적 품질 향상  

---

## 관련 이슈 (Related Issues)
- Related to #71

