### PR TITLE
Revert "SSR 및 API 통합 개선을 위한 프로젝트 구성 및 데이터 패칭 로직 업데이트"

### DIFF
--- a/.github/workflows/deploy-optimized.yml
+++ b/.github/workflows/deploy-optimized.yml
@@ -58,7 +58,7 @@ jobs:
         env:
           NEXT_PUBLIC_TMDB_API_KEY: ${{ secrets.VITE_TMDB_API_KEY }}
           NEXT_PUBLIC_TMDB_BASE_URL: https://api.themoviedb.org/3
-          NEXT_PUBLIC_TMDB_IMAGE_URL: https://image.tmdb.org/t/p/original
+          NEXT_PUBLIC_TMDB_IMAGE_URL: https://image.tmdb.org/t/p/w500
         run: |
           # ES Modules 이슈 해결을 위한 임시 조치
           cd apps/watcha_clone_coding

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pnpm start
 # TMDB API 설정
 VITE_TMDB_API_KEY=your_tmdb_api_key_here
 VITE_TMDB_BASE_URL=https://api.themoviedb.org/3
-VITE_TMDB_IMAGE_URL=https://image.tmdb.org/t/p/original
+VITE_TMDB_IMAGE_URL=https://image.tmdb.org/t/p/w500
 
 # 앱 설정
 APP_PHASE=local

--- a/apps/watcha_clone_coding/README.md
+++ b/apps/watcha_clone_coding/README.md
@@ -12,7 +12,7 @@
 # TMDB API 설정
 VITE_TMDB_API_KEY=your_tmdb_api_key_here
 VITE_TMDB_BASE_URL=https://api.themoviedb.org/3
-VITE_TMDB_IMAGE_URL=https://image.tmdb.org/t/p/original
+VITE_TMDB_IMAGE_URL=https://image.tmdb.org/t/p/w500
 
 # 앱 설정
 APP_PHASE=local

--- a/apps/watcha_clone_coding/config/env.ts
+++ b/apps/watcha_clone_coding/config/env.ts
@@ -3,7 +3,7 @@
 export const config = {
   tmdbApiKey: process.env.NEXT_PUBLIC_TMDB_API_KEY,
   tmdbBaseUrl: process.env.NEXT_PUBLIC_TMDB_BASE_URL || 'https://api.themoviedb.org/3',
-  tmdbImageUrl: process.env.NEXT_PUBLIC_TMDB_IMAGE_URL || 'https://image.tmdb.org/t/p/original',
+  tmdbImageUrl: process.env.NEXT_PUBLIC_TMDB_IMAGE_URL || 'https://image.tmdb.org/t/p/w500',
 };
 
 // 환경변수 검증 (개발 환경에서만)
@@ -14,11 +14,4 @@ if (process.env.NODE_ENV === 'development' && !config.tmdbApiKey) {
 // 프로덕션 환경에서는 API 키가 반드시 필요
 if (process.env.NODE_ENV === 'production' && !config.tmdbApiKey) {
   throw new Error('NEXT_PUBLIC_TMDB_API_KEY가 설정되지 않았습니다. 프로덕션 배포를 위해 API 키를 설정해주세요.');
-}
-
-// 서버 사이드에서 빌드 시 체크
-if (typeof window === 'undefined' && process.env.NODE_ENV === 'production') {
-  if (!process.env.NEXT_PUBLIC_TMDB_API_KEY) {
-    throw new Error('NEXT_PUBLIC_TMDB_API_KEY가 설정되지 않았습니다.');
-  }
 }

--- a/apps/watcha_clone_coding/next-env.d.ts
+++ b/apps/watcha_clone_coding/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./dist/types/routes.d.ts" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/apps/watcha_clone_coding/next.config.mjs
+++ b/apps/watcha_clone_coding/next.config.mjs
@@ -1,16 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    // output: 'export', // Single-Page Application (SPA) 출력. -> SSR 적용을 위해 비활성화
+    output: 'export', // Single-Page Application (SPA) 출력.
     distDir: './dist', // 빌드 출력 디렉터리를 `./dist/`로 변경합니다.
     transpilePackages: ['@watcha/carousel'], // 트랜스파일링할 패키지 목록
     images: {
-      remotePatterns: [
-        {
-          protocol: 'https',
-          hostname: 'image.tmdb.org',
-          pathname: '/t/p/**',
-        },
-      ],
+      unoptimized: true, // 정적 export 시 이미지 최적화 비활성화
     },
     webpack: (config) => {
       config.module.rules.push({

--- a/apps/watcha_clone_coding/src/pages/SearchHomePage.tsx
+++ b/apps/watcha_clone_coding/src/pages/SearchHomePage.tsx
@@ -1,13 +1,8 @@
-import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { Carousel } from '@watcha/carousel';
-import { GetStaticProps } from 'next';
 import Head from 'next/head';
 import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
-
-import { searchListKeys } from '../queries/search/queryKeys';
-import { fetchMovieGenres, fetchTodayTrendingMovie } from '../utils/api';
 
 import AppErrorBoundary from '@/components/AppErrorBoundary';
 import GenresCard from '@/components/GenresCard';
@@ -34,41 +29,6 @@ const TAB_BUTTONS = [
     name: '다른 장르 보기 V',
   },
 ];
-
-export const getStaticProps: GetStaticProps = async () => {
-  const queryClient = new QueryClient();
-
-  try {
-    // 기존 hook과 동일한 queryKey, queryFn 사용
-    await Promise.all([
-      queryClient.prefetchQuery({
-        queryKey: searchListKeys.trending(),
-        queryFn: fetchTodayTrendingMovie,
-      }),
-      queryClient.prefetchQuery({
-        queryKey: searchListKeys.genres(),
-        queryFn: fetchMovieGenres,
-      }),
-    ]);
-
-    return {
-      props: {
-        dehydratedState: dehydrate(queryClient),
-      },
-      revalidate: 3600, // 1시간마다 재생성
-    };
-  } catch (error) {
-    console.error('Failed to prefetch movie data:', error);
-
-    // 에러 발생 시 빈 상태로 반환 (클라이언트에서 재시도)
-    return {
-      props: {
-        dehydratedState: dehydrate(queryClient),
-      },
-      revalidate: 60,
-    };
-  }
-};
 
 const SearchHomePageContent = () => {
   const { highlightedIndex, handleMouseEnter } = useSearchMovies();

--- a/apps/watcha_clone_coding/src/pages/_app.tsx
+++ b/apps/watcha_clone_coding/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider, HydrationBoundary } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AppProps } from 'next/app';
 import { useState } from 'react';
 
@@ -24,8 +24,6 @@ export default function App({ Component, pageProps }: AppProps) {
             retryDelay: (attemptIndex: number): number => Math.min(1000 * 2 ** attemptIndex, 30000), // 지수 백오프
             refetchOnWindowFocus: false, // 윈도우 포커스 시 자동 리페치 비활성화
             refetchOnReconnect: true, // 네트워크 재연결 시 리페치
-            // SSR에서 prefetch된 데이터는 재요청하지 않도록
-            refetchOnMount: false,
           },
         },
       }),
@@ -34,11 +32,9 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <AppErrorBoundary>
       <QueryClientProvider client={queryClient}>
-        <HydrationBoundary state={pageProps.dehydratedState}>
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
-        </HydrationBoundary>
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
       </QueryClientProvider>
     </AppErrorBoundary>
   );

--- a/apps/watcha_clone_coding/src/pages/index.tsx
+++ b/apps/watcha_clone_coding/src/pages/index.tsx
@@ -1,6 +1,4 @@
-import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { Carousel } from '@watcha/carousel';
-import { GetStaticProps } from 'next';
 import Head from 'next/head';
 import React from 'react';
 
@@ -8,10 +6,8 @@ import AppErrorBoundary from '@/components/AppErrorBoundary';
 import MovieCard from '@/components/MovieCard';
 import { PageSkeleton } from '@/components/Skeleton';
 import ThemeTab from '@/components/ThemeTab';
-import { movieListKeys } from '@/queries/movieList/queryKeys';
 import { useMovieListQuery } from '@/queries/movieList/useMovieListQuery';
 import { CarouselProps } from '@/types/Carousel';
-import { fetchPopularMovieList, fetchTopRatedMovieList, fetchNowPlayingMovieList } from '@/utils/api';
 
 const TAB_BUTTONS = [
   {
@@ -30,45 +26,6 @@ const TAB_BUTTONS = [
     name: '성인+',
   },
 ];
-
-export const getStaticProps: GetStaticProps = async () => {
-  const queryClient = new QueryClient();
-
-  try {
-    // 기존 hook과 동일한 queryKey, queryFn 사용
-    await Promise.all([
-      queryClient.prefetchQuery({
-        queryKey: movieListKeys.popular(),
-        queryFn: fetchPopularMovieList,
-      }),
-      queryClient.prefetchQuery({
-        queryKey: movieListKeys.top_rated(),
-        queryFn: fetchTopRatedMovieList,
-      }),
-      queryClient.prefetchQuery({
-        queryKey: movieListKeys.now_playing(),
-        queryFn: fetchNowPlayingMovieList,
-      }),
-    ]);
-
-    return {
-      props: {
-        dehydratedState: dehydrate(queryClient),
-      },
-      revalidate: 3600, // 1시간마다 재생성
-    };
-  } catch (error) {
-    console.error('Failed to prefetch movie data:', error);
-
-    // 에러 발생 시 빈 상태로 반환 (클라이언트에서 재시도)
-    return {
-      props: {
-        dehydratedState: dehydrate(queryClient),
-      },
-      revalidate: 60,
-    };
-  }
-};
 
 const ListPageContent = () => {
   const { popularQuery, topRatedQuery, nowPlayingQuery } = useMovieListQuery();

--- a/apps/watcha_clone_coding/src/pages/movie/[id].tsx
+++ b/apps/watcha_clone_coding/src/pages/movie/[id].tsx
@@ -1,11 +1,6 @@
-import { dehydrate, QueryClient } from '@tanstack/react-query';
-import { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
 import Image from 'next/image';
 import React from 'react';
-
-import { movieDetailKeys } from '../../queries/detail/queryKeys';
-import { fetchMovieDetail, fetchMovieReviews, fetchPopularMovieList } from '../../utils/api';
 
 import AssessmentIcon from '@/assets/assuessment.svg';
 import InterestIcon from '@/assets/interest.svg';
@@ -17,64 +12,6 @@ import { DetailPageSkeleton } from '@/components/Skeleton';
 import useMovieDetail from '@/hooks/useMovieDetail';
 import { Genre, Member, Review, Video } from '@/types/Movie';
 import { buildImageUrl } from '@/utils/transform';
-
-// 어떤 페이지를 미리 생성할지
-export const getStaticPaths: GetStaticPaths = async () => {
-  try {
-    // 인기 영화 목록 빌드 타임에 생성
-    const movies = await fetchPopularMovieList();
-
-    const paths = movies.slice(0, 50).map((movie) => ({
-      params: { id: movie.id.toString() },
-    }));
-
-    return {
-      paths,
-      fallback: 'blocking', // 나머지 영화는 첫 요청 시 생성
-    };
-  } catch (error) {
-    console.error('Error in getStaticPaths:', error);
-
-    return {
-      paths: [],
-      fallback: 'blocking',
-    };
-  }
-};
-
-// getStaticProps - 각 페이지의 데이터 prefetch
-export const getStaticProps: GetStaticProps = async ({ params }) => {
-  const movieId = params?.id as string;
-  const queryClient = new QueryClient();
-
-  try {
-    // 영화 상세 정보와 리뷰를 병렬로 prefetch
-    await Promise.all([
-      queryClient.prefetchQuery({
-        queryKey: movieDetailKeys.detail(movieId),
-        queryFn: () => fetchMovieDetail(movieId),
-      }),
-      queryClient.prefetchQuery({
-        queryKey: movieDetailKeys.reviews(movieId),
-        queryFn: () => fetchMovieReviews(movieId),
-      }),
-    ]);
-
-    return {
-      props: {
-        dehydratedState: dehydrate(queryClient),
-      },
-      revalidate: 86400, // 24시간마다 재생성 (영화 정보는 거의 안 바뀜)
-    };
-  } catch (error) {
-    console.error(`Error fetching movie ${movieId}:`, error);
-
-    // 404 페이지로
-    return {
-      notFound: true,
-    };
-  }
-};
 
 const DetailPageContent: React.FC = () => {
   const { movieData, reviews, getReleaseYear, changeTimeFormat } = useMovieDetail();

--- a/apps/watcha_clone_coding/src/utils/api.tsx
+++ b/apps/watcha_clone_coding/src/utils/api.tsx
@@ -1,85 +1,67 @@
-// utils/api.tsx
 import { instance } from '@/utils/axios';
 import { transformMovieList, transformMovieData } from '@/utils/transform';
 
-const defaultMovieParams = {
+const movieListQueryString = new URLSearchParams({
   language: 'ko-KR',
-  page: 1,
-};
+  page: '1',
+});
 
 export const fetchPopularMovieList = () =>
-  instance
-    .get('/movie/popular', { params: defaultMovieParams })
-    .then((response) => transformMovieList(response.data.results));
+  instance.get(`/movie/popular?${movieListQueryString}`).then((response) => transformMovieList(response.data.results));
 
 export const fetchTopRatedMovieList = () =>
   instance
-    .get('/movie/top_rated', { params: defaultMovieParams })
+    .get(`/movie/top_rated?${movieListQueryString}`)
     .then((response) => transformMovieList(response.data.results));
 
 export const fetchNowPlayingMovieList = () =>
   instance
-    .get('/movie/now_playing', { params: defaultMovieParams })
+    .get(`/movie/now_playing?${movieListQueryString}`)
     .then((response) => transformMovieList(response.data.results));
 
+const movieDetailQueryString = new URLSearchParams({
+  language: 'ko-KR',
+  append_to_response: 'credits,videos,belongs_to_collection',
+});
+
 export const fetchMovieDetail = (movieId: string) =>
-  instance
-    .get(`/movie/${movieId}`, {
-      params: {
-        language: 'ko-KR',
-        append_to_response: 'credits,videos,belongs_to_collection',
-      },
-    })
-    .then((response) => {
-      if (!response.data || !response.data.id) {
-        throw new Error(`영화 ID ${movieId}에 대한 데이터를 찾을 수 없습니다.`);
-      }
-      return transformMovieData(response.data);
-    });
+  instance.get(`/movie/${movieId}?${movieDetailQueryString}`).then((response) => {
+    if (!response.data || !response.data.id) {
+      throw new Error(`영화 ID ${movieId}에 대한 데이터를 찾을 수 없습니다.`);
+    }
+    return transformMovieData(response.data);
+  });
+
+const movieReviewsQueryString = new URLSearchParams({
+  language: 'en-US',
+  page: '1',
+});
 
 export const fetchMovieReviews = (movieId: string) =>
   instance
-    .get(`/movie/${movieId}/reviews`, {
-      params: {
-        language: 'en-US',
-        page: 1,
-      },
-    })
+    .get(`/movie/${movieId}/reviews?${movieReviewsQueryString}`)
     .then((response) => response.data || { results: [] });
 
+const movieTrendingQueryString = new URLSearchParams({
+  language: 'ko-KR',
+});
+
 export const fetchTodayTrendingMovie = () =>
-  instance
-    .get('/trending/movie/day', {
-      params: { language: 'ko-KR' },
-    })
-    .then((response) => response.data.results);
+  instance.get(`/trending/movie/day?${movieTrendingQueryString}`).then((response) => response.data.results);
+
+const movieGenresQueryString = new URLSearchParams({
+  language: 'ko',
+});
 
 export const fetchMovieGenres = () =>
-  instance
-    .get('/genre/movie/list', {
-      params: { language: 'ko' },
-    })
-    .then((response) => response.data.genres);
+  instance.get(`/genre/movie/list?${movieGenresQueryString}`).then((response) => response.data.genres);
 
 export const fetchSearchKeywords = (query: string) =>
   instance
-    .get('/search/movie', {
-      params: {
-        query,
-        include_adult: false,
-        language: 'ko-KR',
-        page: 1,
-      },
-    })
+    .get(`/search/movie?query=${query}&include_adult=false&${movieListQueryString}`)
     .then((response) => transformMovieList(response.data.results, { usePoster: true }));
 
 export const fetchSearchGenres = (genreId: string) =>
   instance
-    .get('/discover/movie', {
-      params: {
-        with_genres: genreId,
-        language: 'ko-KR',
-        page: 1,
-      },
-    })
+    .get(`/discover/movie?with_genres=${genreId}&${movieListQueryString}`)
     .then((response) => transformMovieList(response.data.results, { usePoster: true }));


### PR DESCRIPTION
## 개요 (Summary)
- 이 PR은 GitHub Actions 워크플로우 내에서 `turbo` 명령어를 직접 실행하도록 변경한 이전 커밋을 **되돌리기(Revert)** 위한 것입니다.  
해당 변경은 CI 파이프라인 실행 중 오류가 발생하여, 안정적인 `pnpm` 기반 워크플로우로 복구합니다.

---

## 변경 사항 (Changes)
- GitHub Actions 워크플로우 내 `turbo run build`, `turbo run lint` 명령어 제거  
- 기존 `pnpm run build`, `pnpm run lint` 스크립트로 복귀  
- `.turbo` 관련 캐시 설정(`cache: 'turbo'`) 제거  

---

## 관련 이슈 (Related Issues)
- Related to #88

