### PR TITLE
GitHub Pages 및 Storybook 설정 업데이트

### DIFF
--- a/.github/GITHUB_PAGES_SETUP.md
+++ b/.github/GITHUB_PAGES_SETUP.md
@@ -58,12 +58,12 @@ git push origin main
 배포 완료 후 다음 URL로 접속:
 
 ```
-https://[GitHub사용자명].github.io/watcha_clone_coding/
+https://[GitHub사용자명].github.io/flickmosaic/
 ```
 
 예시:
 
-- `https://orbital0m0.github.io/watcha_clone_coding/`
+- `https://orbital0m0.github.io/flickmosaic/`
 
 > 💡 **팁**: Actions 탭의 워크플로우 상세 페이지에서 정확한 URL을 확인할 수 있습니다.
 
@@ -110,7 +110,7 @@ python -m http.server 8000
 ```typescript
 viteFinal: async (config) => {
   if (process.env.NODE_ENV === 'production') {
-    config.base = '/watcha_clone_coding/'; // 저장소 이름과 일치해야 함
+    config.base = '/flickmosaic/'; // 저장소 이름과 일치해야 함
   }
   return config;
 },
@@ -135,7 +135,7 @@ viteFinal: async (config) => {
 배포된 URL을 팀원들과 공유하세요:
 
 ```
-https://[사용자명].github.io/watcha_clone_coding/
+https://[사용자명].github.io/flickmosaic/
 ```
 
 ---

--- a/packages/carousel/.storybook/main.ts
+++ b/packages/carousel/.storybook/main.ts
@@ -11,7 +11,7 @@ const config: StorybookConfig = {
   viteFinal: async (config) => {
     // production 환경에서만 베이스 경로 설정
     if (process.env.NODE_ENV === 'production') {
-      config.base = '/watcha_clone_coding/';
+      config.base = '/flickmosaic/';
     }
     return config;
   },


### PR DESCRIPTION
## 개요 (Summary)
이 PR은 프로젝트 이름 변경에 따라 **GitHub Pages 배포 설정**과 **Storybook 구성**을  
`watcha_clone_coding` → **`flickmosaic`** 으로 업데이트한 내용입니다.  
관련 URL, 베이스 경로, 문서 내용을 모두 새로운 프로젝트 이름에 맞게 조정했습니다.

---

## 변경 사항 (Changes)
- `GITHUB_PAGES_SETUP.md` 문서에서 프로젝트 이름 및 GitHub Pages URL을 **flickmosaic**으로 변경  
- `storybook/main.ts`, `storybook/preview.ts` 등 Storybook 설정에서 베이스 경로 수정  
- Storybook 배포용 GitHub Actions 워크플로에서 `flickmosaic` 이름 반영  
- Storybook 문서 내 프로젝트 링크 및 타이틀 업데이트 


