### PR TITLE
refactor: 불필요한 스타일 임포트 제거 ✂️

### DIFF
--- a/apps/flickmosaic/src/pages/_app.tsx
+++ b/apps/flickmosaic/src/pages/_app.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 
 import AppErrorBoundary from '../components/AppErrorBoundary';
 import Layout from '../layouts/Layout';
-import '@orbital0m0/carousel/styles';
 import '@/styles/App.css';
 
 export default function App({ Component, pageProps }: AppProps) {


### PR DESCRIPTION
## 📝 개요 (Summary)
프로젝트 전반에서 사용되던 **`@orbital0m0/carousel/styles` import를 제거**하여  
불필요한 스타일 의존성을 정리하고 코드 구조를 단순화했습니다.

현재 Carousel 컴포넌트 스타일은 **Tailwind CSS 기반으로 완전히 전환된 상태**이므로  
외부 스타일 패키지 import는 더 이상 필요하지 않습니다.

이를 제거함으로써 **불필요한 스타일 로딩을 방지하고 성능을 개선**했습니다.

---

## 🔧 변경 사항 (Changes)

- `@orbital0m0/carousel/styles` import 제거
- Tailwind 기반 스타일 구조와 충돌 가능성 제거
- 불필요한 스타일 의존성 정리
- 코드 가독성 및 유지보수성 개선

---

## 관련 이슈 (Related Issues)
- Closes #122
- Related to #122

